### PR TITLE
Refactor keypoint implementation

### DIFF
--- a/data/coco-kpts.yaml
+++ b/data/coco-kpts.yaml
@@ -1,0 +1,13 @@
+# train and val data as 1) directory: path/images/, 2) file: path/images.txt, or 3) list: [path1/images/, path2/images/]
+path: ../datasets/coco
+train: train2017.txt  # 118287 images
+val: val2017.txt  # 5000 images
+
+skeleton: [[16,14],[14,12],[17,15],[15,13],[12,13],[6,12],[7,13],[6,7],
+            [6,8],[7,9],[8,10],[9,11],[2,3],[1,2],[1,3],[2,4],[3,5],[4,6],[5,7]]
+
+# number of classes
+nc: 1
+nkpt: 17
+
+names: ['person']

--- a/data/hand-kpts.yaml
+++ b/data/hand-kpts.yaml
@@ -1,0 +1,13 @@
+# train and val data as 1) directory: path/images/, 2) file: path/images.txt, or 3) list: [path1/images/, path2/images/]
+path: ../datasets/hand_labels
+train: train/
+val: test/
+
+skeleton: [[1, 2], [2, 3], [3, 4], [4, 5], [1, 6], [6, 7], [7, 8], [8, 9], [1, 10], [10, 11], [11, 12],
+           [12, 13], [1, 14], [14, 15], [15, 16], [16, 17], [1, 18], [18, 19], [19, 20], [20, 21]]
+
+# number of classes
+nc: 1
+nkpt: 21
+
+names: ['hand']

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -57,7 +57,9 @@ class Detect(nn.Module):
         z = []  # inference output
         for i in range(self.nl):
             x[i] = self.m[i](x[i])  # conv
-            bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
+            bs, _, ny, nx = x[i].shape
+
+            # x(bs,255,20,20) to x(bs,3,20,20,85)
             x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
 
             if not self.training:  # inference
@@ -82,9 +84,10 @@ class Detect(nn.Module):
         d = self.anchors[i].device
         t = self.anchors[i].dtype
         shape = 1, self.na, ny, nx, 2  # grid shape
-        y, x = torch.arange(ny, device=d, dtype=t), torch.arange(nx, device=d, dtype=t)
+        y = torch.arange(ny, device=d, dtype=t)
+        x = torch.arange(nx, device=d, dtype=t)
         yv, xv = torch.meshgrid(y, x, indexing='ij') if torch_1_10 else torch.meshgrid(y, x)  # torch>=0.7 compatibility
-        grid = torch.stack((xv, yv), 2).expand(shape) - 0.5  # add grid offset, i.e. y = 2.0 * x - 0.5
+        grid = torch.stack((xv, yv), 2).expand(shape) - 0.5 # add grid offset, i.e. y = 2.0 * x - 0.5
         anchor_grid = (self.anchors[i] * self.stride[i]).view((1, self.na, 1, 1, 2)).expand(shape)
         return grid, anchor_grid
 
@@ -107,57 +110,50 @@ class Segment(Detect):
 
 
 class Keypoint(Detect):
-    def __init__(self, nc=80, anchors=(), nkpt=None, ch=(), inplace=True, dw_conv_kpt=False):
+    def __init__(self, nc=80, anchors=(), nkpt=None, ch=(), inplace=True):
         super().__init__(nc, anchors, ch, inplace)
-        self.nkpt = nkpt # number of keypoints
-        self.dw_conv_kpt = dw_conv_kpt
-        self.no_kpt = 3 * self.nkpt # number of outputs per anchor for keypoints
+        self.nkpt = nkpt  # number of keypoints
+        self.no_kpt = 3 * self.nkpt  # number of outputs per anchor for keypoints
         self.no_det = nc + 5  # number of outputs per anchor for box and class
-        self.no = self.no_det + self.no_kpt # number of outputs per anchor
+        self.no = self.no_det + self.no_kpt  # number of outputs per anchor
         self.m = nn.ModuleList(nn.Conv2d(x, self.no_det * self.na, 1) for x in ch)  # output conv
         self.detect = Detect.forward
 
         if self.nkpt is not None:
-            if self.dw_conv_kpt: #keypoint head is slightly more complex
-                self.m_kpt = nn.ModuleList(
-                            nn.Sequential(DWConv(x, x, k=3), Conv(x,x),
-                                          DWConv(x, x, k=3), Conv(x, x),
-                                          DWConv(x, x, k=3), Conv(x,x),
-                                          DWConv(x, x, k=3), Conv(x, x),
-                                          DWConv(x, x, k=3), Conv(x, x),
-                                          DWConv(x, x, k=3), nn.Conv2d(x, self.no_kpt * self.na, 1)) for x in ch)
-            else: #keypoint head is a single convolution
-                self.m_kpt = nn.ModuleList(nn.Conv2d(x, self.no_kpt * self.na, 1) for x in ch)
-    
-    def forward(self, x):
-        z = []  # inference output
+            self.m_kpt = nn.ModuleList(nn.Conv2d(x, self.no_kpt * self.na, 1) for x in ch)
+
+    def forward(self, head_features):
+        output = []  # inference output
         for i in range(self.nl):
-            x[i] = torch.cat((self.m[i](x[i]), self.m_kpt[i](x[i])), axis=1)        
-            bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
-            x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
-            x_det = x[i][..., :6]
-            x_kpt = x[i][..., 6:]
+            head_features[i] = torch.cat((self.m[i](head_features[i]), self.m_kpt[i](head_features[i])), axis=1)
+            bs, _, ny, nx = head_features[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
+            head_features[i] = head_features[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
+            x_det = head_features[i][..., :6]  # (obj, conf, x, y, w, h)
+            x_kpt = head_features[i][..., 6:]  # (kpt_i_x, kpt_i_y, kpt_i_conf)
 
             if not self.training:  # inference
-                if self.dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:
+                if self.dynamic or self.grid[i].shape[2:4] != head_features[i].shape[2:4]:
                     self.grid[i], self.anchor_grid[i] = self._make_grid(nx, ny, i)
 
                 kpt_grid_x = self.grid[i][..., 0:1]
                 kpt_grid_y = self.grid[i][..., 1:2]
 
                 y = x_det.sigmoid()
-                
-                xy = (y[..., 0:2] * 2 + self.grid[i]) * self.stride[i]  # xy
-                wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i] # wh
-                if self.nkpt != 0:
-                    x_kpt[..., 0::3] = (x_kpt[..., ::3] * 2. + kpt_grid_x.repeat(1,1,1,1,17)) * self.stride[i]  # xy
-                    x_kpt[..., 1::3] = (x_kpt[..., 1::3] * 2. + kpt_grid_y.repeat(1,1,1,1,17)) * self.stride[i]  # xy
-                    x_kpt[..., 2::3] = x_kpt[..., 2::3].sigmoid()
-                y = torch.cat((xy, wh, y[..., 4:], x_kpt), -1)
-                z.append(y.view(bs, -1, self.no))
 
-        return x if self.training else (torch.cat(z, 1),) if self.export else (torch.cat(z, 1), x)
-        
+                xy = (y[..., 0:2] * 2 + self.grid[i]) * self.stride[i]  # xy
+                wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
+                if self.nkpt != 0:
+                    x_kpt[..., 0::3] = (x_kpt[..., ::3] * 2.
+                                        + kpt_grid_x.repeat(1, 1, 1, 1, self.nkpt)) * self.stride[i]  # xy
+                    x_kpt[..., 1::3] = (x_kpt[..., 1::3] * 2.
+                                        + kpt_grid_y.repeat(1, 1, 1, 1, self.nkpt)) * self.stride[i]  # xy
+
+                    x_kpt[..., 2::3] = x_kpt[..., 2::3].sigmoid()  # visibility confidence
+                y = torch.cat((xy, wh, y[..., 4:], x_kpt), -1)
+                output.append(y.view(bs, -1, self.no))
+
+        return head_features if self.training else (torch.cat(output, 1),) if self.export else (torch.cat(output, 1), head_features)
+
 
 class BaseModel(nn.Module):
     # YOLOv5 base model
@@ -217,7 +213,7 @@ class BaseModel(nn.Module):
 
 class DetectionModel(BaseModel):
     # YOLOv5 detection model
-    def __init__(self, cfg='yolov5s.yaml', ch=3, nc=None, anchors=None):  # model, input channels, number of classes
+    def __init__(self, cfg='yolov5s.yaml', ch=3, nc=None, nkpt=None, anchors=None):  # model, input channels, number of classes
         super().__init__()
         if isinstance(cfg, dict):
             self.yaml = cfg  # model dict
@@ -232,6 +228,9 @@ class DetectionModel(BaseModel):
         if nc and nc != self.yaml['nc']:
             LOGGER.info(f"Overriding model.yaml nc={self.yaml['nc']} with nc={nc}")
             self.yaml['nc'] = nc  # override yaml value
+        if nkpt and nkpt != self.yaml['nkpt']:
+            LOGGER.info(f"Overriding model.yaml nkpt={self.yaml['nkpt']} with nkpt={nkpt}")
+            self.yaml['nkpt'] = nkpt
         if anchors:
             LOGGER.info(f'Overriding model.yaml anchors with anchors={anchors}')
             self.yaml['anchors'] = round(anchors)  # override yaml value
@@ -348,6 +347,7 @@ class ClassificationModel(BaseModel):
         # Create a YOLOv5 classification model from a *.yaml file
         self.model = None
 
+
 class KeypointModel(DetectionModel):
     def __init__(self, cfg='yolov5s-kpt.yaml', ch=3, nc=None, anchors=None):
         super().__init__(cfg, ch, nc, anchors)
@@ -375,9 +375,8 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
                 args[j] = eval(a) if isinstance(a, str) else a  # eval strings
 
         n = n_ = max(round(n * gd), 1) if n > 1 else n  # depth gain
-        if m in {
-                Conv, GhostConv, Bottleneck, GhostBottleneck, SPP, SPPF, DWConv, MixConv2d, Focus, CrossConv,
-                BottleneckCSP, C3, C3TR, C3SPP, C3Ghost, nn.ConvTranspose2d, DWConvTranspose2d, C3x}:
+        if m in {Conv, GhostConv, Bottleneck, GhostBottleneck, SPP, SPPF, DWConv, MixConv2d, Focus, CrossConv,
+                 BottleneckCSP, C3, C3TR, C3SPP, C3Ghost, nn.ConvTranspose2d, DWConvTranspose2d, C3x}:
             c1, c2 = ch[f], args[0]
             if c2 != no:  # if not output
                 c2 = make_divisible(c2 * gw, 8)
@@ -386,9 +385,10 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
             if m in {BottleneckCSP, C3, C3TR, C3Ghost, C3x}:
                 args.insert(2, n)  # number of repeats
                 n = 1
-            if m in [Conv, GhostConv, Bottleneck, GhostBottleneck, DWConv, MixConv2d, Focus, CrossConv, BottleneckCSP, C3, C3TR]:
+            if m in [Conv, GhostConv, Bottleneck, GhostBottleneck, DWConv, MixConv2d, Focus, CrossConv, BottleneckCSP,
+                     C3, C3TR]:
                 if 'act' in d.keys():
-                    args_dict = {"act" : d['act']}
+                    args_dict = {"act": d['act']}
         elif m is nn.BatchNorm2d:
             args = [ch[f]]
         elif m is Concat:
@@ -400,8 +400,6 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
                 args[1] = [list(range(args[1] * 2))] * len(f)
             if m is Segment:
                 args[3] = make_divisible(args[3] * gw, 8)
-            if m is Keypoint:
-                args_dict = {"dw_conv_kpt" : d['dw_conv_kpt']}
         elif m is Contract:
             c2 = ch[f] * args[0] ** 2
         elif m is Expand:

--- a/models/yolov5s-kpt.yaml
+++ b/models/yolov5s-kpt.yaml
@@ -5,7 +5,6 @@ nc: 1  # number of classes
 nkpt: 17 # number of keypoints
 depth_multiple: 0.33  # model depth multiple
 width_multiple: 0.5  # layer channel multiple
-dw_conv_kpt: False
 
 anchors:
   - [ 19,27,  44,40,  38,94 ]  # P3/8

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -149,8 +149,8 @@ def random_perspective(im,
                        scale=.1,
                        shear=10,
                        perspective=0.0,
-                       border=(0, 0), 
-                       kpt_label=0):
+                       border=(0, 0),
+                       n_kpt=0):
     # torchvision.transforms.RandomAffine(degrees=(-10, 10), translate=(0.1, 0.1), scale=(0.9, 1.1), shear=(-10, 10))
     # targets = [cls, xyxy]
 
@@ -229,28 +229,28 @@ def random_perspective(im,
             # clip
             new[:, [0, 2]] = new[:, [0, 2]].clip(0, width)
             new[:, [1, 3]] = new[:, [1, 3]].clip(0, height)
-            if kpt_label:
-                xy_kpts = np.ones((n * kpt_label, 3))
-                xy_kpts[:, :2] = targets[:,5:].reshape(n * kpt_label, 2)  
-                xy_kpts = xy_kpts @ M.T # transform
+            if n_kpt:
+                xy_kpts = np.ones((n * n_kpt, 3))
+                xy_kpts[:, :2] = targets[:, 5:].reshape(n * n_kpt, 2)
+                xy_kpts = xy_kpts @ M.T  # transform
                 if perspective:
-                    xy_kpts = (xy_kpts[:, :2] / xy_kpts[:, 2:3]).reshape(n, 2 * kpt_label) # perspective rescale
+                    xy_kpts = (xy_kpts[:, :2] / xy_kpts[:, 2:3]).reshape(n, 2 * n_kpt)  # perspective rescale
                 else:
-                    xy_kpts = xy_kpts[:, :2].reshape(n, 2 * kpt_label) # affine
-                xy_kpts[targets[:, 5:]==0] = 0
-                x_kpts = xy_kpts[:, list(range(0, 2 * kpt_label, 2))]
-                y_kpts = xy_kpts[:, list(range(1, 2 * kpt_label, 2))]
+                    xy_kpts = xy_kpts[:, :2].reshape(n, 2 * n_kpt)  # affine
+                xy_kpts[targets[:, 5:] == 0] = 0
+                x_kpts = xy_kpts[:, list(range(0, 2 * n_kpt, 2))]
+                y_kpts = xy_kpts[:, list(range(1, 2 * n_kpt, 2))]
 
                 x_kpts[np.logical_or.reduce((x_kpts < 0, x_kpts > width, y_kpts < 0, y_kpts > height))] = 0
                 y_kpts[np.logical_or.reduce((x_kpts < 0, x_kpts > width, y_kpts < 0, y_kpts > height))] = 0
-                xy_kpts[:, list(range(0, 2 * kpt_label, 2))] = x_kpts
-                xy_kpts[:, list(range(1, 2 * kpt_label, 2))] = y_kpts
+                xy_kpts[:, list(range(0, 2 * n_kpt, 2))] = x_kpts
+                xy_kpts[:, list(range(1, 2 * n_kpt, 2))] = y_kpts
 
         # filter candidates
         i = box_candidates(box1=targets[:, 1:5].T * s, box2=new.T, area_thr=0.01 if use_segments else 0.10)
         targets = targets[i]
         targets[:, 1:5] = new[i]
-        if kpt_label:
+        if n_kpt:
             targets[:, 5:] = xy_kpts[i]
 
     return im, targets

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -250,7 +250,7 @@ class Loggers():
         if self.comet_logger:
             self.comet_logger.on_val_end(nt, tp, fp, p, r, f1, ap, ap50, ap_class, confusion_matrix)
     
-    def on_val_end_kpt(self, nt, tp, fp, p, r, f1, ap, ap50, ap50_kpt, ap_kpt, ap_class, confusion_matrix, kpt_label):
+    def on_val_end_kpt(self, nt, tp, fp, p, r, f1, ap, ap50, ap50_kpt, ap_kpt, ap_class, confusion_matrix, n_kpt):
         # Callback runs on val end
         if self.wandb or self.clearml:
             files = sorted(self.save_dir.glob('val*.jpg'))
@@ -260,11 +260,11 @@ class Loggers():
                 self.clearml.log_debug_samples(files, title='Validation')
 
         if self.comet_logger:
-            self.comet_logger.on_val_end(nt, tp, fp, p, r, f1, ap, ap50, ap_class, confusion_matrix, kpt_label, ap50_kpt, ap_kpt)
+            self.comet_logger.on_val_end(nt, tp, fp, p, r, f1, ap, ap50, ap_class, confusion_matrix, n_kpt, ap50_kpt, ap_kpt)
 
-    def on_fit_epoch_end(self, vals, epoch, best_fitness, fi, kpt_label):
+    def on_fit_epoch_end(self, vals, epoch, best_fitness, fi, n_kpt):
         # Callback runs at the end of each fit (train+val) epoch
-        if kpt_label:
+        if n_kpt:
             x = dict(zip(self.kpt_keys, vals))
             if self.csv:
                 file = self.save_dir / 'results.csv'

--- a/utils/loggers/comet/__init__.py
+++ b/utils/loggers/comet/__init__.py
@@ -90,7 +90,7 @@ class CometLogger:
             "log_code": False,
             "log_env_gpu": True,
             "log_env_cpu": True,
-            "project_name": COMET_PROJECT_NAME,}
+            "project_name": COMET_PROJECT_NAME, }
         self.default_experiment_kwargs.update(experiment_kwargs)
         self.experiment = self._get_experiment(self.comet_mode, run_id)
 
@@ -152,7 +152,7 @@ class CometLogger:
             "comet_log_per_class_metrics": COMET_LOG_PER_CLASS_METRICS,
             "comet_log_batch_metrics": COMET_LOG_BATCH_METRICS,
             "comet_log_confusion_matrix": COMET_LOG_CONFUSION_MATRIX,
-            "comet_model_name": COMET_MODEL_NAME,})
+            "comet_model_name": COMET_MODEL_NAME, })
 
         # Check if running the Experiment with the Comet Optimizer
         if hasattr(self.opt, "comet_optimizer_id"):
@@ -169,7 +169,7 @@ class CometLogger:
                     **self.default_experiment_kwargs,
                 )
 
-            return comet_ml.OfflineExperiment(**self.default_experiment_kwargs,)
+            return comet_ml.OfflineExperiment(**self.default_experiment_kwargs, )
 
         else:
             try:
@@ -213,7 +213,7 @@ class CometLogger:
             "fitness_score": fitness_score[-1],
             "epochs_trained": epoch + 1,
             "save_period": opt.save_period,
-            "total_epochs": opt.epochs,}
+            "total_epochs": opt.epochs, }
 
         model_files = glob.glob(f"{path}/*.pt")
         for model_path in model_files:
@@ -269,7 +269,7 @@ class CometLogger:
                     "x": xyxy[0],
                     "y": xyxy[1],
                     "x2": xyxy[2],
-                    "y2": xyxy[3]},})
+                    "y2": xyxy[3]}, })
         for *xyxy, conf, cls in filtered_detections.tolist():
             metadata.append({
                 "label": f"{self.class_names[int(cls)]}",
@@ -278,7 +278,7 @@ class CometLogger:
                     "x": xyxy[0],
                     "y": xyxy[1],
                     "x2": xyxy[2],
-                    "y2": xyxy[3]},})
+                    "y2": xyxy[3]}, })
 
         self.metadata_dict[image_name] = metadata
         self.logged_images_count += 1
@@ -461,25 +461,25 @@ class CometLogger:
 
         return
 
-    def on_val_end(self, nt, tp, fp, p, r, f1, ap, ap50, ap_class, confusion_matrix, kpt_label=0, map50_kpt=0, map_kpt=0):
+    def on_val_end(self, nt, tp, fp, p, r, f1, ap, ap50, ap_class, confusion_matrix, n_kpt=0, map50_kpt=0, map_kpt=0):
         if self.comet_log_per_class_metrics:
             if self.num_classes > 1:
                 for i, c in enumerate(ap_class):
                     class_name = self.class_names[c]
-                    if kpt_label:
+                    if n_kpt:
                         self.experiment.log_metrics(
-                        {
-                            'mAP@.5': ap50[i],
-                            'mAP@.5:.95': ap[i],
-                            'mAP_kpt@.5':map50_kpt[i],
-                            'mAP_kpt@.5:.95':map_kpt[i],
-                            'precision': p[i],
-                            'recall': r[i],
-                            'f1': f1[i],
-                            'true_positives': tp[i],
-                            'false_positives': fp[i],
-                            'support': nt[c]},
-                        prefix=class_name)
+                            {
+                                'mAP@.5': ap50[i],
+                                'mAP@.5:.95': ap[i],
+                                'mAP_kpt@.5': map50_kpt[i],
+                                'mAP_kpt@.5:.95': map_kpt[i],
+                                'precision': p[i],
+                                'recall': r[i],
+                                'f1': f1[i],
+                                'true_positives': tp[i],
+                                'false_positives': fp[i],
+                                'support': nt[c]},
+                            prefix=class_name)
                     else:
                         self.experiment.log_metrics(
                             {


### PR DESCRIPTION
Now object detection and keypoints regression can be trained using the same code.
Number of keypoints works as number of classes in detection model: value from dataset.yaml is mkore important than model.yaml.
detect.py use skeleton and nkpt from dataset.yaml.
Remove DWConvs in keypoint heads.
